### PR TITLE
fix: Add FAQ (and more) to users manual (#1237)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
-## Documentation of Back In Time
+# Users documentation of Back In Time
+This is the source repository for [User
+Documentation](https://backintime.readthedocs.io) of [Back In
+Time](https://github.com/bit-team/backintime).
 
-[![Documentation Status](https://readthedocs.org/projects/backintime/badge/?version=latest)](http://backintime.readthedocs.org/en/latest/?badge=latest)
+Feel free to [open issues](https://github.com/bit-team/backintime/issues).
 
-
-This is the source of the documentation of [Back In Time](https://github.com/bit-team/backintime). The documentation
-it self is in [backintime.rtfd.org](https://backintime.rtfd.org/). See the [Back In Time repository](https://github.com/bit-team/backintime) repository for further information and an [issue tracker](https://github.com/bit-team/backintime/issues).
+## Build and generate
+To build this documentation with
+[Sphinx](http://www.sphinx-doc.org/en/stable/) and generate HTML files out of
+do `make html` in the repository you cloned before. After this start with the
+index file `_build/html/index.html` in your browser.
 
 ## Contribute
 
-Help on writing the new doc is highly appreciate! The doc is written in
-[reStructuredText](http://docutils.sourceforge.net/docs/user/rst/quickref.html)
-and build with [Sphinx](http://www.sphinx-doc.org/en/stable/).
-To view the pages locally you can run `make html` in the root folder of this
-repository and then open `_build/html/index.html` in your browser.
+Helping with and contributing to documentation isn't just writing. Feel free
+to [suggest](https://github.com/bit-team/backintime/issues) topics, a new
+structure or everything that might improve the content.
 
-The build on `Read the Docs` will automatically be updated after committing to
-this branch.
+The build on [Read the Docs](https://readthedocs.org) will automatically be
+updated after committing to
+
+<sub>May 2023</sub>
+

--- a/additional.rst
+++ b/additional.rst
@@ -1,0 +1,16 @@
+Additional sources
+==================
+
+- `FAQ - Frequently Asked Questions
+  <https://github.com/bit-team/backintime/blob/dev/FAQ.md>`_
+- `Source code documentation for developers
+  <https://backintime-dev.readthedocs.org>`_
+- `Issue Tracker
+  <https://github.com/bit-team/backintime/issues>`_
+- Mailing list `bit-dev
+  <https://mail.python.org/mailman3/lists/bit-dev.python.org>`_ (`Archive
+  <https://mail.python.org/archives/list/bit-dev@python.org/latest?count=200>`_)
+- `Contributing to Back In Time
+  <https://github.com/bit-team/backintime/blob/dev/CONTRIBUTING.md>`_
+- `Project Website at Microsoft GitHub
+  <https://github.com/bit-team/backintime>`_

--- a/conf.py
+++ b/conf.py
@@ -13,19 +13,19 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-import shlex
+# import sys
+# import os
+# import shlex
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -41,7 +41,7 @@ templates_path = ['_templates']
 source_suffix = '.rst'
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
 master_doc = 'index'
@@ -69,9 +69,9 @@ language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -79,27 +79,27 @@ exclude_patterns = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -114,26 +114,26 @@ html_theme = 'sphinx_rtd_theme'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -143,86 +143,89 @@ html_static_path = ['_static']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'h', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'r', 'sv', 'tr'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'BackInTimeDoc'
+
 
 def setup(app):
     """
     add custom stylesheet
     """
-    app.add_stylesheet("css/custom.css")
+    # app.add_stylesheet("css/custom.css")  # deprecated
+    app.add_css_file("css/custom.css")
 
 # -- Options for LaTeX output ---------------------------------------------
 
+
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
 
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # Latex figure (float) alignment
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
@@ -235,23 +238,23 @@ latex_documents = [
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
@@ -264,7 +267,7 @@ man_pages = [
 ]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -279,13 +282,13 @@ texinfo_documents = [
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False

--- a/index.rst
+++ b/index.rst
@@ -16,6 +16,7 @@ Contents:
     settings
     snapshotsdialog
     log
+    additional
 
 ------------
 

--- a/makeScreenshots.py
+++ b/makeScreenshots.py
@@ -18,17 +18,16 @@
 import sys
 import os
 import subprocess
-from PyQt5.QtGui import QPixmap
 from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QDialog
-from tempfile import TemporaryDirectory, NamedTemporaryFile
-from time import sleep
+from tempfile import TemporaryDirectory
 from datetime import date, time, datetime, timedelta
 
 os.environ['LANGUAGE'] = 'en_US.UTF-8'
 
 sys.path.insert(0, '../backintime/common')
 sys.path.insert(0, '../backintime/qt')
+
 import app
 import settingsdialog
 import qttools
@@ -37,6 +36,7 @@ import snapshots
 from guiapplicationinstance import GUIApplicationInstance
 from snapshotsdialog import SnapshotsDialog
 from logviewdialog import LogViewDialog
+
 
 def setScreenshotTimer(widget, filename, width = 720, hight = 480):
     widget.move(100, 50)
@@ -56,6 +56,7 @@ def setScreenshotTimer(widget, filename, width = 720, hight = 480):
     scrTimer.start()
     quitTimer.start()
     qapp.exec_()
+
 
 def setScreenshotTimerDlg(mainWindow, dlgFunct, filename):
     def close():
@@ -96,11 +97,13 @@ def setScreenshotTimerDlg(mainWindow, dlgFunct, filename):
     dlgMoveTimer.start()
     qapp.exec_()
 
+
 def takeScreenshot(filename):
     cmd = ['scrot', '-b', '-u', filename]
     # print(cmd)
     proc = subprocess.Popen(cmd)
     proc.communicate()
+
 
 with TemporaryDirectory() as tmp:
     cfgFile = os.path.join(tmp, 'config')
@@ -125,7 +128,9 @@ with TemporaryDirectory() as tmp:
     ### Snapshot Log View ###
     #########################
 
-    cmd = ['../backintime/common/backintime', '--config', cfgFile, 'backup']
+    backintime_exec = '../backintime/common/backintime'
+    # backintime_exec = 'backintime'
+    cmd = [backintime_exec, '--config', cfgFile, 'backup']
     proc = subprocess.Popen(cmd)
     proc.communicate()
 


### PR DESCRIPTION
Add a section _Additional sources_ to the users manual generated via Sphinx. That section is a list of links pointing to different resources related to Back In Time.

I also
 - updated the README.md
 - made minor PEP8 related modifications in conf.py and makeScreenshots.py. The latter doesn't work and lacks of documentation. But the idea is nice. It seems to start BIT opening some windows and taking them as screenshots *automatically*. 
 - Fixed a Sphinx deprecation warning in conf.py

I haven't touched the docus version number because the docu itself keeps a bit outdated.

Fix [#1237](https://github.com/bit-team/backintime/issues/1237)

Let me give you the result as screenshots to prevent you from building yourself.

![grafik](https://user-images.githubusercontent.com/11861496/236677045-c3547471-394c-4497-8164-a9c7c98acc5d.png)

![grafik](https://user-images.githubusercontent.com/11861496/236677063-08347129-3b24-47a0-a0eb-6a31d1b99862.png)
