### PR TITLE
Doc/quickstart

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -12,6 +12,7 @@ Contents:
 .. toctree::
     :maxdepth: 2
 
+    quick-start
     mainwindow
     settings
     snapshotsdialog

--- a/quick-start.rst
+++ b/quick-start.rst
@@ -1,0 +1,10 @@
+Quick start
+===========
+
+- Start _Back In Time_ from your applications menu.
+- Select a destination directory for backups in the ``General`` tab (USB drive/local directory/network location...).
+- Optionally, select a schedule for automatic backups (e.g. every week).
+- In the ``Include`` tab, add files/directories to backup (e.g. Documents, Music...).
+- Save your settings with ``OK``.
+- Start the backup operation.
+

--- a/quick-start.rst
+++ b/quick-start.rst
@@ -1,7 +1,7 @@
 Quick start
 ===========
 
-- Start _Back In Time_ from your applications menu.
+- Start *Back In Time* from your applications menu.
 - Select a destination directory for backups in the ``General`` tab (USB drive/local directory/network location...).
 - Optionally, select a schedule for automatic backups (e.g. every week).
 - In the ``Include`` tab, add files/directories to backup (e.g. Documents, Music...).


### PR DESCRIPTION
Add a Quickstart section to the user docu.

There is still room for improvement. But that also applies to the rest of the documentation. I like the idea of having a Quickstart section.

I found an old PR (#2) from @nodiscc . It is form 2019 and he closed it herself/himself two years later because no one answered or merged. Microsoft GitHub do not allow me to re-open that Issue because the source repo/branch is deleted.